### PR TITLE
moving merging of `meta` tables to `utils.py` for re-use in `subtract()`

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -201,7 +201,7 @@ class IamDataFrame(object):
         ret = copy.deepcopy(self) if not inplace else self
 
         # merge `meta` tables
-        merge_meta(ret, other, ignore_meta_conflict)
+        ret.meta = merge_meta(ret.meta, other.meta, ignore_meta_conflict)
 
         # append other.data (verify integrity for no duplicates)
         _data = ret.data.set_index(sorted(ret._LONG_IDX)).append(

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -23,6 +23,7 @@ from pyam.utils import (
     read_pandas,
     format_data,
     sort_data,
+    merge_meta,
     to_int,
     find_depth,
     pattern_match,
@@ -199,37 +200,8 @@ class IamDataFrame(object):
 
         ret = copy.deepcopy(self) if not inplace else self
 
-        diff = other.meta.index.difference(ret.meta.index)
-        intersect = other.meta.index.intersection(ret.meta.index)
-
-        # merge other.meta columns not in self.meta for existing scenarios
-        if not intersect.empty:
-            # if not ignored, check that overlapping meta dataframes are equal
-            if not ignore_meta_conflict:
-                cols = [i for i in other.meta.columns if i in ret.meta.columns]
-                if not ret.meta.loc[intersect, cols].equals(
-                        other.meta.loc[intersect, cols]):
-                    conflict_idx = (
-                        pd.concat([ret.meta.loc[intersect, cols],
-                                   other.meta.loc[intersect, cols]]
-                                  ).drop_duplicates()
-                        .index.drop_duplicates()
-                    )
-                    msg = 'conflict in `meta` for scenarios {}'.format(
-                        [i for i in pd.DataFrame(index=conflict_idx).index])
-                    raise ValueError(msg)
-
-            cols = [i for i in other.meta.columns if i not in ret.meta.columns]
-            _meta = other.meta.loc[intersect, cols]
-            ret.meta = ret.meta.merge(_meta, how='outer',
-                                      left_index=True, right_index=True)
-
-        # join other.meta for new scenarios
-        if not diff.empty:
-            # sorting not supported by ` pd.append()`  prior to version 23
-            sort_kwarg = {} if int(pd.__version__.split('.')[1]) < 23 \
-                else dict(sort=False)
-            ret.meta = ret.meta.append(other.meta.loc[diff, :], **sort_kwarg)
+        # merge `meta` tables
+        merge_meta(ret, other, ignore_meta_conflict)
 
         # append other.data (verify integrity for no duplicates)
         _data = ret.data.set_index(sorted(ret._LONG_IDX)).append(

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -174,9 +174,10 @@ class IamDataFrame(object):
 
     def append(self, other, ignore_meta_conflict=False, inplace=False,
                **kwargs):
-        """Append any castable object to this IamDataFrame.
-        Columns in `other.meta` that are not in `self.meta` are always merged,
-        duplicate region-variable-unit-year rows raise a ValueError.
+        """Append any castable object to this ``IamDataFrame``
+
+        Columns in ``other.meta`` that are not in ``self.meta`` are merged.
+        Conflicting region-variable-unit-year rows raise a ``ValueError``.
 
         Parameters
         ----------
@@ -208,7 +209,7 @@ class IamDataFrame(object):
             other.data.set_index(sorted(other._LONG_IDX)),
             verify_integrity=True)
 
-        # merge extra columns in `data` and set `LONG_IDX`
+        # merge extra columns in `data` and set `self._LONG_IDX`
         ret.extra_cols += [i for i in other.extra_cols
                            if i not in ret.extra_cols]
         ret._LONG_IDX = IAMC_IDX + [ret.time_col] + ret.extra_cols

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -289,9 +289,7 @@ def merge_meta(ret, other, ignore_meta_conflict):
 
     # join other.meta for new scenarios
     if not diff.empty:
-        sort_kwarg = {} if int(pd.__version__.split('.')[1]) < 23 \
-            else dict(sort=False)
-        ret.meta = ret.meta.append(other.meta.loc[diff, :], **sort_kwarg)
+        ret.meta = ret.meta.append(other.meta.loc[diff, :], sort=False)
 
 def find_depth(data, s='', level=None):
     """

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -260,36 +260,36 @@ def sort_data(data, cols):
     return data.sort_values(cols)[cols + ['value']].reset_index(drop=True)
 
 
-def merge_meta(ret, other, ignore_meta_conflict):
-    """Merge the ``meta`` tables of two ``IamDataFrames; raise error if values are in conflict (optional)"""
-    diff = other.meta.index.difference(ret.meta.index)
-    intersect = other.meta.index.intersection(ret.meta.index)
+def merge_meta(left, right, ignore_meta_conflict=False):
+    """Merge two ``meta`` tables; raise if values are in conflict (optional)"""
+    left = left.copy()  # make a copy to not change the original object
+    diff = right.index.difference(left.index)
+    sect = right.index.intersection(left.index)
 
-    # merge other.meta columns not in self.meta for existing scenarios
-    if not intersect.empty:
-        # if not ignored, check that overlapping meta dataframes are equal
+    # merge `right` into `left` for overlapping scenarios ( `sect`)
+    if not sect.empty:
+        # if not ignored, check that overlapping `meta` columns are equal
         if not ignore_meta_conflict:
-            cols = [i for i in other.meta.columns if i in ret.meta.columns]
-            if not ret.meta.loc[intersect, cols].equals(
-                    other.meta.loc[intersect, cols]):
+            cols = [i for i in right.columns if i in left.columns]
+            if not left.loc[sect, cols].equals(right.loc[sect, cols]):
                 conflict_idx = (
-                    pd.concat([ret.meta.loc[intersect, cols],
-                               other.meta.loc[intersect, cols]]
+                    pd.concat([right.loc[sect, cols], left.loc[sect, cols]]
                               ).drop_duplicates()
                         .index.drop_duplicates()
                 )
                 msg = 'conflict in `meta` for scenarios {}'.format(
                     [i for i in pd.DataFrame(index=conflict_idx).index])
                 raise ValueError(msg)
+        #
+        cols = [i for i in right.columns if i not in left.columns]
+        left = left.merge(right.loc[sect, cols], how='outer',
+                          left_index=True, right_index=True)
 
-        cols = [i for i in other.meta.columns if i not in ret.meta.columns]
-        _meta = other.meta.loc[intersect, cols]
-        ret.meta = ret.meta.merge(_meta, how='outer',
-                                  left_index=True, right_index=True)
-
-    # join other.meta for new scenarios
+    # join other.meta for new scenarios (`diff`)
     if not diff.empty:
-        ret.meta = ret.meta.append(other.meta.loc[diff, :], sort=False)
+        left = left.append(right.loc[diff, :], sort=False)
+
+    return left
 
 def find_depth(data, s='', level=None):
     """

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -260,6 +260,39 @@ def sort_data(data, cols):
     return data.sort_values(cols)[cols + ['value']].reset_index(drop=True)
 
 
+def merge_meta(ret, other, ignore_meta_conflict):
+    """Merge the ``meta`` tables of two ``IamDataFrames; raise error if values are in conflict (optional)"""
+    diff = other.meta.index.difference(ret.meta.index)
+    intersect = other.meta.index.intersection(ret.meta.index)
+
+    # merge other.meta columns not in self.meta for existing scenarios
+    if not intersect.empty:
+        # if not ignored, check that overlapping meta dataframes are equal
+        if not ignore_meta_conflict:
+            cols = [i for i in other.meta.columns if i in ret.meta.columns]
+            if not ret.meta.loc[intersect, cols].equals(
+                    other.meta.loc[intersect, cols]):
+                conflict_idx = (
+                    pd.concat([ret.meta.loc[intersect, cols],
+                               other.meta.loc[intersect, cols]]
+                              ).drop_duplicates()
+                        .index.drop_duplicates()
+                )
+                msg = 'conflict in `meta` for scenarios {}'.format(
+                    [i for i in pd.DataFrame(index=conflict_idx).index])
+                raise ValueError(msg)
+
+        cols = [i for i in other.meta.columns if i not in ret.meta.columns]
+        _meta = other.meta.loc[intersect, cols]
+        ret.meta = ret.meta.merge(_meta, how='outer',
+                                  left_index=True, right_index=True)
+
+    # join other.meta for new scenarios
+    if not diff.empty:
+        sort_kwarg = {} if int(pd.__version__.split('.')[1]) < 23 \
+            else dict(sort=False)
+        ret.meta = ret.meta.append(other.meta.loc[diff, :], **sort_kwarg)
+
 def find_depth(data, s='', level=None):
     """
     return or assert the depth (number of `|`) of variables

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -280,12 +280,12 @@ def merge_meta(left, right, ignore_meta_conflict=False):
                 msg = 'conflict in `meta` for scenarios {}'.format(
                     [i for i in pd.DataFrame(index=conflict_idx).index])
                 raise ValueError(msg)
-        #
+        # merge new columns
         cols = [i for i in right.columns if i not in left.columns]
         left = left.merge(right.loc[sect, cols], how='outer',
                           left_index=True, right_index=True)
 
-    # join other.meta for new scenarios (`diff`)
+    # join `other.meta` for new scenarios (`diff`)
     if not diff.empty:
         left = left.append(right.loc[diff, :], sort=False)
 


### PR DESCRIPTION
**Note: This PR fails because the underlying `znicholls:substration` is failing.**

## Description

Following up on my comment https://github.com/IAMconsortium/pyam/pull/276#discussion_r343057912 (which wasn't sufficiently clear, sorry), this PR implements the suggested change.

The PR moves the entire merging and consistency-checking for two `meta` tables from `append()` into an own function in `utils.py` so that it can be re-used in `subtract()` and other operations functions.

## Illustrative example of merging `meta` - why bother?

Assume you have an `IamDataFrame` with temperature, total CO2 emissions, and energy CO2 emissions. You want to use `subtract()` to get "other CO2 emissions" and do some analysis on that.

0. `df = IamDataFrame(...)`
0. apply some categorization on `df` based on temperature
0. `co2 = df.filter(variable='Emissions|CO2')`
0. compute some quantitative indicator on `co2` (e.g. cumulative total emissions)
0. `co2_ene = df.filter(variable='Emissions|CO2|Energy')`
0. compute some quantitative indicator on `co2_ene` (e.g. cumulative emissions from energy)
0. `co2_other = co2.subtract(co2_ene, ...)`

### Expected behaviour

In order to efficiently continue working with `co2_other`, you would probably like to have all previous meta-indicators and categorization attached, without any hassle. E.g., one might want to do a line plot using the temperature categorization. Therefore, merging both `meta` tables and attaching it to the returned object is the user-friendly way forward.

Note that both `co2` and `co2_ene` will have the 'temperature'  categorization, but each instance will have only one of the cumulative indicator.

### Possible issues

One could see a situation where the `meta` tables of the two operated-on `IamDataFrame` instances are conflicting. Per default in `append()`, this would raise a `ValueError`; however, this can be overridden by setting `ignore_meta_conflict=True`. I suggest to implement the same option and default in `subtract()`.

## Better documentation

This is quite a long description for a simple PR - but I wasn't sure how obvious it is. If you have any idea if/where this would make sense to include in the docs, I'm all ears...