### PR TITLE
adding a `data` section

### DIFF
--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -84,7 +84,7 @@ The :class:`IamDataFrame` class
 -------------------------------
 
 A :class:`pyam.IamDataFrame` instance is a wrapper for
-two :class:`pandas.DataFrame` instances (i.e., tables, read the `pandas docs`_
+two :class:`pandas.DataFrame` instances (i.e., tables, see the `pandas docs`_
 for more information).
 
 .. _`pandas docs`: https://pandas.pydata.org/pandas-docs/stable/reference/frame.html

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -79,26 +79,37 @@ mode (beta):
 Please reach out to the developers to get more information on this
 ongoing work.
 
-The :class:`pyam.IamDataFrame` class
-------------------------------------
+The :class:`IamDataFrame` class
+-------------------------------
 
 A :class:`pyam.IamDataFrame` instance is a wrapper for
-two :class:`pandas.DataFrame` instances (read the `docs`_):
+two :class:`pandas.DataFrame` instances (i.e., tables, read the `pandas docs`_
+for more information).
 
- - :code:`data`: The data table is a dataframe containing the timeseries data
-   in "long format". It has the columns of the long data format :code:`['model',
-   'scenario', 'region', 'unit', 'year', 'value']`.
+.. _`pandas docs`: https://pandas.pydata.org/pandas-docs/stable/reference/frame.html
 
- - :code:`meta`: The meta table is a dataframe containing categorisation and
-   descriptive indicators. It has the index :code:`pyam.META_IDX = ['model',
-   'scenario']`.
+The :code:`data` table
+~~~~~~~~~~~~~~~~~~~~~~
 
-The standard output format is the IAMC-style "wide format", see the example
-above. This format can be accessed using :meth:`pyam.IamDataFrame.timeseries`,
-which returns a :class:`pandas.DataFrame` with the index :code:`pyam.IAMC_IDX =
-['model', 'scenario', 'region', 'variable', 'unit']` and the timesteps as columns.
+This table contains the timeseries data related to an ensemble of scenarios.
+It is structured in *long format*, where each datapoint is one row. In contrast,
+the standard IAMC-style format is in *wide format* (see the example above),
+where each timeseries is one row and the timesteps are represented as columns.
 
-.. _`docs`: https://pandas.pydata.org/pandas-docs/stable/reference/frame.html
+While long-format tables have advantages for the internal implementation of many
+:class:`pyam` functions, wide-format tables are more intuitive to users.
+The method :meth:`timeseries() <pyam.IamDataFrame.timeseries>` converts between
+the formats and returns a :class:`pandas.DataFrame` in wide format.
+Exporting an :class:`IamDataFrame` to file using
+:meth:`to_excel() <pyam.IamDataFrame.to_excel>` or
+:meth:`to_csv() <pyam.IamDataFrame.to_csv>` also writes the data table
+in wide format.
+
+The columns of the :code:`data` table are :code:`['model', 'scenario', 'region',
+'unit', <time_format>, 'value']`, where :code:`time_format` is :code:`year`
+when timesteps are given in years (as :class:`int`) or :code:`time` when time
+is represented on a continuous scale (as :class:`pandas.datetime`. Not all
+:class:`pyam` functions currently support the second use case.
 
 The :code:`meta` table
 ----------------------

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -68,7 +68,7 @@ In its original design, the IAMC data format (see above) assumed that the
 temporal dimension of any scenario data was restricted to full years
 represented as integer values.
 
-Two additional use cases are currently supported by :code:`pyam` in development
+Two additional use cases are currently supported by :class:`pyam` in development
 mode (beta):
 
  - using representative sub-annual timesteps via the :code:`extra_cols` feature
@@ -147,8 +147,8 @@ scenario.
     with :code:`NaN` in many cases
     (see `here <https://stackoverflow.com/a/18431417>`_ and
     `here <https://stackoverflow.com/a/13606221>`_).
-    Therefore, it is simpler to remove :code:`NaN`'s to ensure that :class:`pyam`
-    has a clean dataset on which to operate.
+    Therefore, it is simpler to remove :code:`NaN`'s to ensure that
+    :class:`pyam` has a clean dataset on which to operate.
 
 
 The :code:`meta` table

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -136,6 +136,21 @@ scenario.
     mailing list or GitHub issues if you are not sure whether your use cases
     is supported.
 
+.. warning::
+
+    A word of warning for adding data-point-specific annotations using custom
+    columns: :class:`pyam` drops any data rows which have :code:`NaN` values.
+    Hence, if you're adding meta information to :code:`data`, you need to make
+    sure that you **add a value to every single row**.
+
+    The reason for that implementation is that pandas does not work as expected
+    with :code:`NaN` in many cases
+    (see `here <https://stackoverflow.com/a/18431417>`_ and
+    `here <https://stackoverflow.com/a/13606221>`_).
+    Therefore, it is simpler to remove :code:`NaN`'s to ensure that :class:`pyam`
+    has a clean dataset on which to operate.
+
+
 The :code:`meta` table
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -71,13 +71,16 @@ represented as integer values.
 Two additional use cases are currently supported by :code:`pyam` in development
 mode (beta):
 
- - using representative sub-annual timesteps
+ - using representative sub-annual timesteps via the :code:`extra_cols` feature
+   (see the section on `custom data columns`__)
 
  - using continuous time via :class:`pandas.datetime`, replacing the name of
    the :code:`year` column by :code:`time`
 
 Please reach out to the developers to get more information on this
 ongoing work.
+
+__ extra_cols_
 
 The :class:`IamDataFrame` class
 -------------------------------
@@ -105,11 +108,26 @@ Exporting an :class:`IamDataFrame` to file using
 :meth:`to_csv() <pyam.IamDataFrame.to_csv>` also writes the data table
 in wide format.
 
+The standard columns
+^^^^^^^^^^^^^^^^^^^^
+
 The columns of the :code:`data` table are :code:`['model', 'scenario', 'region',
 'unit', <time_format>, 'value']`, where :code:`time_format` is :code:`year`
 when timesteps are given in years (as :class:`int`) or :code:`time` when time
-is represented on a continuous scale (as :class:`pandas.datetime`. Not all
-:class:`pyam` functions currently support the second use case.
+is represented on a continuous scale (as :class:`pandas.datetime`.
+
+.. _extra_cols:
+
+Custom columns of the :code:`data` table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If an :class:`IamDataFrame` is initialised with columns that are neither in the
+list above nor can be interpreted as time dimension (in wide format), these
+columns are included in the :code:`data` table as :code:`extra_cols`.
+This feature can be used, for example, to distinguish between multiple stylized
+climate model providing different values for the variable
+:code:`Temperature|Global Mean` derived from the emissions timeseries of a
+scenario.
 
 The :code:`meta` table
 ----------------------

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -112,26 +112,26 @@ The standard columns
 The columns of the :code:`data` table are :code:`['model', 'scenario', 'region',
 'unit', <time_format>, 'value']`, where :code:`time_format` is :code:`year`
 when timesteps are given in years (as :class:`int`) or :code:`time` when time
-is represented on a continuous scale (as :class:`pandas.datetime`.
+is represented on a continuous scale (as :class:`pandas.datetime`).
 
 .. _`custom columns`:
 
 Custom columns of the :code:`data` table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If an :class:`IamDataFrame` is initialised with columns that are neither in the
-list above nor can be interpreted as time dimension (in wide format), these
+If an :class:`IamDataFrame` is initialised with columns that are not in the
+list above nor interpreted as belonging to the time dimension (in wide format), these
 columns are included in the :code:`data` table as :code:`extra_cols`.
-This feature can be used, for example, to distinguish between multiple stylized
-climate model providing different values for the variable
-:code:`Temperature|Global Mean` derived from the emissions timeseries of a
-scenario.
+This feature can be used, for example, to distinguish between multiple
+climate models providing different values for the variable
+:code:`Temperature|Global Mean`
+.
 
 .. warning::
 
-    Not all :class:`pyam` functions currently support the use with continuous
-    time or custom columns of the :code:`data` table. Please reach out via the 
-    mailing list or GitHub issues if you are not sure whether your use cases
+    Not all :class:`pyam` functions currently support the continuous
+    time or custom columns in a :code:`data` table. Please reach out via the 
+    mailing list or GitHub issues if you are not sure whether your use case
     is supported.
 
 .. warning::

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -129,6 +129,13 @@ climate model providing different values for the variable
 :code:`Temperature|Global Mean` derived from the emissions timeseries of a
 scenario.
 
+.. warning::
+
+    Not all :class:`pyam` functions currently support the use with continuous
+    time or custom columns of the :code:`data` table. Please reach out via the 
+    mailing list or GitHub issues if you are not sure whether your use cases
+    is supported.
+
 The :code:`meta` table
 ----------------------
 

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,8 +1,8 @@
 Data Model
 ==========
 
-Scenario data following the IAMC format
----------------------------------------
+The IAMC timeseries format for scenario data
+--------------------------------------------
 
 .. figure:: _static/iamc_logo.jpg
    :width: 120px
@@ -136,9 +136,9 @@ scenario.
 
 .. warning::
 
-    A word of warning for adding data-point-specific annotations using custom
-    columns: :class:`pyam` drops any data rows which have :code:`NaN` values.
-    Hence, if you're adding meta information to :code:`data`, you need to make
+    A word of warning for adding annotations relating to custom columns:
+    :class:`pyam` drops any data rows which have :code:`NaN` values.
+    Hence, if you are adding meta information to :code:`data`, you need to make
     sure that you **add a value to every single row**.
 
     The reason for that implementation is that pandas does not work as expected
@@ -147,7 +147,6 @@ scenario.
     `here <https://stackoverflow.com/a/13606221>`_).
     Therefore, it is simpler to remove :code:`NaN`'s to ensure that
     :class:`pyam` has a clean dataset on which to operate.
-
 
 The :code:`meta` table
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -178,16 +177,17 @@ Filtering
 
 The |pyam| package provides two methods for filtering scenario data:
 
-An existing `class`:IamDataFrame can be filtered using
-:meth:`pyam.IamDataFrame.filter(col=...) <pyam.IamDataFrame.filter>`,
-where :code:`col` can be any column of the
-:code:`data` table (i.e., `['model', 'scenario', 'region', 'unit', 'year']`)
-or any column of the :code:`meta` table. The returned object is
-a new :class:`pyam.IamDataFrame` instance.
+An existing :class:`IamDataFrame` can be filtered using
+:meth:`filter(col=...) <pyam.IamDataFrame.filter>`,
+where :code:`col` can be any column of the :code:`data` table (i.e.,
+:code:`['model', 'scenario', 'region', 'unit', 'year'/'time']` or any `custom
+columns`_), or a column of the :code:`meta` table. The returned object is
+a new :class:`IamDataFrame` instance.
 
-A :class:`pandas.DataFrame` with columns or index :code:`['model', 'scenario']`
-can be filtered by any :code:`meta` columns from a :code:`pyam.IamDataFrame`
-using :func:`pyam.filter_by_meta(data, df, col=..., join_meta=False) <pyam.filter_by_meta>`.
+A :class:`pandas.DataFrame` (:code:`data`) with columns or index
+:code:`['model', 'scenario']` can be filtered by any :code:`meta` columns from
+an :class:`IamDataFrame` (:code:`df`) using 
+:meth:`pyam.filter_by_meta(data, df, col=..., join_meta=False) <pyam.filter_by_meta>`.
 The returned object is a :class:`pandas.DataFrame` down-selected to those
 models-and-scenarios where the :code:`meta` column satisfies the criteria given
 by :code:`col=...` .

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -150,15 +150,15 @@ CO2 emissions until the end of the century.
 :meth:`append() <pyam.IamDataFrame.append>`).
 See :meth:`utils.merge_meta() <pyam.utils.merge_meta>` for details.
 
-A word of warning for adding data point-specific metadata: :code:`pyam` drops any data rows which have any :code:`NaN` values.
-Similarly, if rows which do not have assigned values, those rows will be dropped by :code:`pyam` or will cause it to behave unexpectedly.
-Hence, if you're adding metadata to :code:`data`, you need to make sure that you **add it to every single row**.
-This begs the question, why does :code:`pyam` drop any data rows which have any :code:`NaN` values?
-The reason is that pandas does not play nicely with :code:`NaN` in many cases (see e.g. `here <https://stackoverflow.com/a/18431417>`_ and `here <https://stackoverflow.com/a/13606221>`_).
-Hence it is simpler to remove all the :code:`NaN`'s, ensuring that :code:`pyam` has a clean dataset on which to operate.
+.. note::
 
-As far as possible, :code:`pyam` attempts to keep the information in :code:`meta` consistent with :code:`data` when performing operations.
-The metadata information is kept using ``pyam.utils.merge_meta``, which will raise conflicts as appropriate.
+    The :code:`meta` table is not intended for annotations of individual
+    data points. If you want to add meta information at this level (e.g., 
+    which stylized climate model provided the variable
+    :code:`Temperature|Global Mean`, or whether a data point is from the 
+    original data source or the result of an operation), this should operate on
+    the :code:`data` table of the :class:`IamDataFrame` using the
+    custom-columns feature (see above).
 
 Filtering
 ---------

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -137,16 +137,18 @@ scenario.
     is supported.
 
 The :code:`meta` table
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
-As mentioned above, every :class:`pyam.IamDataFrame` contains a :code:`meta` attribute
-which is its metadata table.
-This metadata table is intended to contain **metadata at the scenario-model level** only.
-For example, the temperature category a scenario falls into (e.g.'Below 1.5°C', 'Between 1.5°C and 2.0°C' etc.).
+This table is intended for categorisation and quantitative indicators at the
+model-scenario level. Examples in the `SR15`_ context are the warming category 
+('Below 1.5°C', '1.5°C with low overshoot', etc.) and the cumulative
+CO2 emissions until the end of the century.
 
-The metadata table is not intended for specific metadata per individual data point.
-If you want to have metadata at this level, then you should operate on the :code:`data` attribute of the :class:`pyam.IamDataFrame`.
-For example, you could specify whether a given data point is the result of an interpolation or not.
+:class:`pyam` attempts to keep the information in :code:`meta` consistent with
+:code:`data` when performing operations (e.g.,
+:meth:`rename() <pyam.IamDataFrame.rename>`,
+:meth:`append() <pyam.IamDataFrame.append>`).
+See :meth:`utils.merge_meta() <pyam.utils.merge_meta>` for details.
 
 A word of warning for adding data point-specific metadata: :code:`pyam` drops any data rows which have any :code:`NaN` values.
 Similarly, if rows which do not have assigned values, those rows will be dropped by :code:`pyam` or will cause it to behave unexpectedly.

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -72,15 +72,13 @@ Two additional use cases are currently supported by :class:`pyam` in development
 mode (beta):
 
  - using representative sub-annual timesteps via the :code:`extra_cols` feature
-   (see the section on `custom data columns`__)
+   (see the section on `custom columns`_ in the :code:`data` table)
 
  - using continuous time via :class:`pandas.datetime`, replacing the name of
    the :code:`year` column by :code:`time`
 
 Please reach out to the developers to get more information on this
 ongoing work.
-
-__ extra_cols_
 
 The :class:`IamDataFrame` class
 -------------------------------
@@ -116,7 +114,7 @@ The columns of the :code:`data` table are :code:`['model', 'scenario', 'region',
 when timesteps are given in years (as :class:`int`) or :code:`time` when time
 is represented on a continuous scale (as :class:`pandas.datetime`.
 
-.. _extra_cols:
+.. _`custom columns`:
 
 Custom columns of the :code:`data` table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +171,7 @@ See :meth:`utils.merge_meta() <pyam.utils.merge_meta>` for details.
     :code:`Temperature|Global Mean`, or whether a data point is from the 
     original data source or the result of an operation), this should operate on
     the :code:`data` table of the :class:`IamDataFrame` using the
-    custom-columns feature (see above).
+    custom-columns feature (see `custom columns`_ above).
 
 Filtering
 ---------


### PR DESCRIPTION
Following the suggestion by @jkikstra, I removed the introduction overview of the two dataframes and added a proper section on the `data` table, including the custom-columns feature. And I rewrote a lot of the descriptions (sorry, I couldn't help myself) and formatted the as warnings and notes for a more colourful and structured docs page.

I also tried to consistently use the `:class:` tag for `pyam` (it was mixed with `:code:`).